### PR TITLE
fix: do not include products with price 0.00 on the feed

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources"
   },
   "dependencies": {
-    "@vtex/api": "6.45.3"
+    "@vtex/api": "6.45.6"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && tslint -c tslint.json './**/*.ts'"

--- a/node/services/generateProductsFeed.ts
+++ b/node/services/generateProductsFeed.ts
@@ -154,9 +154,10 @@ export async function generateProductsFeed(ctx: Context) {
         await pacer(1000)
       }
 
-      const productFeed = products.map(product =>
-        transformProductToClerk(product, rootPath)
-      )
+      const productFeed = products
+        .map(product => transformProductToClerk(product, rootPath))
+        // Filter undefined products returned from the previous map funciton
+        .filter(product => product) as ClerkProduct[]
 
       await feedManager.saveProductFeed({ productFeed, bindingId })
 

--- a/node/services/generateProductsFeed.ts
+++ b/node/services/generateProductsFeed.ts
@@ -156,7 +156,7 @@ export async function generateProductsFeed(ctx: Context) {
 
       const productFeed = products
         .map(product => transformProductToClerk(product, rootPath))
-        // Filter undefined products returned from the previous map funciton
+        // Filter undefined products returned from the previous map function
         .filter(product => product) as ClerkProduct[]
 
       await feedManager.saveProductFeed({ productFeed, bindingId })

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -122,7 +122,7 @@ export function transformOrderToClerk(orderDetails: Order): ClerkOrder {
 export function getBindingSalesChannel(
   bindings: BindingAppConfig[],
   bindingId: string
-): any {
+): string {
   const [currentBinding] = bindings.filter(
     binding => binding.bindingId === bindingId
   )
@@ -135,7 +135,13 @@ export function getBindingSalesChannel(
 export function transformProductToClerk(
   product: ProductInfo,
   rootPath?: string
-): ClerkProduct {
+): ClerkProduct | undefined {
+  const { sellingPrice, listPrice } = product.priceRange
+
+  if (!sellingPrice.highPrice && !listPrice.highPrice) {
+    return
+  }
+
   const dateString = product.releaseDate ?? new Date()
   // Clerk asks the dates to be a UNIX timestamp (in seconds)
   // .getTime generates it in miliseconds
@@ -149,12 +155,8 @@ export function transformProductToClerk(
     id: product.productId,
     name: product.productName,
     description: product.description,
-    price:
-      product.priceRange.sellingPrice.highPrice ??
-      product.priceRange.sellingPrice.lowPrice,
-    list_price:
-      product.priceRange.listPrice.highPrice ??
-      product.priceRange.listPrice.lowPrice,
+    price: sellingPrice.highPrice ?? sellingPrice.lowPrice,
+    list_price: listPrice.highPrice ?? listPrice.lowPrice,
     image: product.items[0].images[0].imageUrl,
     url: productUrl,
     categories: product.categoryTree.map(category => category.id),

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?
This PR solves an issue for the product feed containing products with price `0`.
When generating the feed, the app uses a query to get a product's information that is then used to generate the product feed.
When a product is unavailable, the `priceRange` for `sellingPrice` and `listPrice` of the product is returned as:
```
priceRange: {
  highPrice: 0,
  lowPrice: null,
}
```
This products should not be included on the product feed.

#### How to test it?
You can see the available bindings on the [app's settings](https://clerkiofeed--powerplanet.myvtex.com/admin/apps/vtex.clerkio-integration@1.1.0/setup/).
You can check the regenerated feed (one without products with price `0`) for the first binding (`es`) making a request with VTEX credentials to the following endpoint:
```
https://app.io.vtex.com/vtex.clerkio-integration/v1/powerplanet/clerkiofeed/_v/clerkio-integration/clerk-feed/:bindingId
```