### PR TITLE
Hotfix/ametller

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "builders": {
     "messages": "1.x",
@@ -29,7 +27,8 @@
     "vtex.graphql-server": "1.x",
     "vtex.render-runtime": "8.x",
     "vtex.store-resources": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.order-manager": "0.x"
   },
   "policies": [
     {

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources"
   },
   "dependencies": {
-    "@vtex/api": "6.45.6"
+    "@vtex/api": "6.45.12"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && tslint -c tslint.json './**/*.ts'"

--- a/node/services/generateProductsFeed.ts
+++ b/node/services/generateProductsFeed.ts
@@ -25,6 +25,7 @@ const createProductsQuery = (
         }
       }
       items {
+        itemId
         images {
           imageUrl
         }

--- a/node/typings/clerkio.d.ts
+++ b/node/typings/clerkio.d.ts
@@ -38,6 +38,7 @@ interface ClerkProduct {
    * @memberOf ClerkProduct
    */
   created_at: number
+  sku_id: string
 }
 
 interface ClerkCategory {

--- a/node/typings/vtex.d.ts
+++ b/node/typings/vtex.d.ts
@@ -25,7 +25,7 @@ interface ProductInfo {
     sellingPrice: PriceRange
     listPrice: PriceRange
   }
-  items: Images[]
+  items: Items[]
   link: string
   linkText: string
   categoryTree: Category[]
@@ -38,7 +38,8 @@ interface PriceRange {
   lowPrice: number
 }
 
-interface Images {
+interface Items {
+  itemId: string
   images: ImageUrl[]
 }
 interface ImageUrl {

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -143,6 +143,7 @@ export function transformProductToClerk(
 
   return {
     id: product.productId,
+    sku_id: product.items[0].itemId,
     name: product.productName,
     description: product.description,
     price:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.6":
-  version "6.45.6"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
-  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
+"@vtex/api@6.45.12":
+  version "6.45.12"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
+  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/typings/vtex.order-manager.d.ts
+++ b/react/typings/vtex.order-manager.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.order-manager/OrderForm'


### PR DESCRIPTION
#### What problem is this solving?

This code enables the button to add to cart in a Clerk shelf to mimic VTEX add to cart button native behavior. The changes are divided in two:

1. node/utils/index.ts
- Add `sku_id` into the feed. It gets the id of the first element inside product items array and add to the product feed. Clerk needs that to call checkout API and add the sku into the order form;

2. react/Block/index.tsx
- Add a custom event (`clerk:orderform:updated`) into the window object to update the minicart. It allows an event outside the React context to access the functions to interact with the minicart. The call to checkout API only adds the sku into the order form in the back end. This syncs the front end.

The main intention of these changes is to show a way to handle that and I don't think it's ready for production. The main concerns are:
1. The function used to update the minicart replaces the whole cart instead of adding a new item;
2. The above implementation doesn't trigger the native user feedback letting the user know a new item was added to cart;
3. It doesn't send information about the event (add to cart) to any pixel app, meaning it will not be tracked by analytic tools.

The hook being used here `useOrderForm` exposes a function called `addToCart` that could be use to fix the problems mentioned above. However, the replacement of it:
1. Needs to be coordinate with Clerk and how they will pass the payload to the event;
2. `addToCart` expects the marketing campaign params about the navigation.

It doesn't seem to be a difficult implementation, but it will need some tests to ensure the native behavior and all process that happens behind the scenes are kept.

#### How to test it?

1. Seen the `sku_id` into the feed:
The new `sku_id` can be seen in this workspace: https://app.io.vtex.com/vtex.clerkio-integration/v1/ametllerorigenqa/filaclerkio/_v/clerkio-integration/clerk-feed/869a9be5-6ce6-4a3c-a47c-39d385391fdd

2. Working with the new custom event:
To test the new event, visit this [workspace](https://filaclerkio--ametllerorigenqa.myvtex.com/) and open the console in the dev tools.

First, update your order form via API (you can replace the order form id in the request below to match the one you have in the cookies):
```js
let orderForm 
fetch('/api/checkout/pub/orderForm/6aa927e7152646e6ba7e838a51bd735c/items', {method: 'PATCH', body: JSON.stringify({"orderItems":[{"quantity":4,"seller":"1","id":"101"}]})}).then(r => r.json()).then(data => orderForm = data)
```

Then, create and dispatch the custom event using the response from checkout:
```js
let updateCart = new CustomEvent('clerk:orderform:updated', { detail: { orderForm }}) 
window.dispatchEvent(updateCart) 
```

If you updated the request to match the order form on your session, you should see the cart updated with the checkout response. So in theory, Clerk just needs to follow the same pattern (I have already shared that with them).
