### PR TITLE
Feature: Adding measurement_unit & unit_multiplier to send to clerk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.7-hkignore] - 2023-01-19
+
+### Added
+
+- Two more attributes added (measurement_unit, unit_multiplier) to the product feed to send to clerk. 
+
 ## [Unreleased]
 
 ## [1.1.5] - 2022-11-25

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "clerkio-integration",
   "vendor": "vtex",
-  "version": "1.1.7-hkignore",
+  "version": "1.1.7-hkignore-beta.1",
   "title": "Clerk.io Integration",
   "description": "Integrate Cler.io powerful personalization to your store. ",
   "billingOptions": {

--- a/node/services/generateProductsFeed.ts
+++ b/node/services/generateProductsFeed.ts
@@ -29,6 +29,8 @@ const createProductsQuery = (
         images {
           imageUrl
         }
+        measurementUnit
+        unitMultiplier
       }
       link
       linkText

--- a/node/typings/clerkio.d.ts
+++ b/node/typings/clerkio.d.ts
@@ -39,6 +39,8 @@ interface ClerkProduct {
    */
   created_at: number
   sku_id: string
+  measurement_unit: string
+  unit_multiplier: number
 }
 
 interface ClerkCategory {

--- a/node/typings/vtex.d.ts
+++ b/node/typings/vtex.d.ts
@@ -41,6 +41,8 @@ interface PriceRange {
 interface Items {
   itemId: string
   images: ImageUrl[]
+  measurementUnit: string
+  unitMultiplier: number
 }
 interface ImageUrl {
   imageUrl: string

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -154,6 +154,8 @@ export function transformProductToClerk(
     description: product.description,
     price: sellingPrice.highPrice,
     list_price: listPrice.highPrice,
+    measurement_unit: product.items[0].measurementUnit,
+    unit_multiplier: product.items[0].unitMultiplier,
     image: product.items[0].images[0].imageUrl,
     url: productUrl,
     categories: product.categoryTree.map(category => category.id),


### PR DESCRIPTION
#### What problem is this solving?
- Adding two more attributes that is needed to send to clerk
<!--- What is the motivation and context for this change? -->
- In our integration with clerk we need this additional attributes in order to us to complete the full display of product info in our web.