### PR TITLE
Fix/brian ametller rerendering clerk content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.1.8] - 2023-01-27
+## [1.1.7-hkignore-beta.1] - 2023-01-27
 
-### fix
+### Fixed
 
 - Fixed issue with re-render clerk content when `orderForm` event is dispatched outside this app integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.8] - 2023-01-27
+
+### fix
+
+- Fixed issue with re-render clerk content when `orderForm` event is dispatched outside this app integration
+
 ## [1.1.7] - 2023-01-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "clerkio-integration",
   "vendor": "vtex",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "title": "Clerk.io Integration",
   "description": "Integrate Cler.io powerful personalization to your store. ",
   "billingOptions": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "clerkio-integration",
   "vendor": "vtex",
-  "version": "1.1.8",
+  "version": "1.1.7-hkignore-beta.1",
   "title": "Clerk.io Integration",
   "description": "Integrate Cler.io powerful personalization to your store. ",
   "billingOptions": {

--- a/react/Block/index.tsx
+++ b/react/Block/index.tsx
@@ -57,7 +57,7 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
     },
   } = useRuntime()
 
-  const { setOrderForm } = useOrderForm()
+  const { setOrderForm, orderForm } = useOrderForm()
 
   const { data, loading } = useQuery<Session>(session, {
     ssr: false,
@@ -65,7 +65,13 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
 
   const handles = useCssHandles(CSS_HANDLES)
 
+  const [updateClerkContent, setUpdateClerkContent] = React.useState<boolean>(true)
+
   useEffect(() => {
+    // dispatch custom event to listen when orderForm change 
+    const updateCartEvent = new CustomEvent('clerk:content:updated', { detail: { orderForm } });
+    window.dispatchEvent(updateCartEvent);
+
     const updateOrderformEvent = (event: Event) => {
       // eslint-disable-next-line no-console
       console.log('clerk:orderform:updated', { event })
@@ -77,6 +83,7 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
       const { orderForm } = event.detail
 
       if (orderForm) {
+        setUpdateClerkContent(false)
         setOrderForm(orderForm)
       } else {
         console.error(
@@ -84,7 +91,6 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
         )
       }
     }
-
     window.removeEventListener('clerk:orderform:updated', updateOrderformEvent)
     window.addEventListener('clerk:orderform:updated', updateOrderformEvent)
 
@@ -94,7 +100,7 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
         updateOrderformEvent
       )
     }
-  }, [setOrderForm])
+  }, [orderForm, setOrderForm])
 
   const dataProps = createClerkDataProps({
     contentLogic,
@@ -112,8 +118,7 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
 
   useEffect(() => {
     const { Clerk } = window
-
-    if (adjustedClassName && templateName && Clerk && !loading) {
+    if (adjustedClassName && templateName && Clerk && !loading && !updateClerkContent) {
       Clerk(
         'content',
         `.${adjustedClassName}`,
@@ -124,7 +129,7 @@ const ClerkIoBlock: StorefrontFunctionComponent<BlockProps> = ({
         }
       )
     }
-  }, [adjustedClassName, contentParamArgs, loading, templateName])
+  }, [adjustedClassName, contentParamArgs, loading, templateName, updateClerkContent])
 
   return adjustedClassName && templateName ? (
     <div className={handles.container}>


### PR DESCRIPTION
#### What problem is this solving?

Avoiding re-rendering clerk content by each call in the eventListener callback (clerk:orderform:updated). Making the clerk content products experience works better.

This is a fix for the previous changes (PR) made into this branch.

#### How to test it?

In the workspace where is working in this version, perform on products(products recommendations) carousel slide next products and perform to any of this products an action add/remove you will see how the content is re-rendering as the carousel starts again at first product, doesn't stay on the product selected.

